### PR TITLE
Fix previos server locations

### DIFF
--- a/lib/rules/rule-location-order.js
+++ b/lib/rules/rule-location-order.js
@@ -55,6 +55,10 @@ function invoke(node, errors, ignored, state) {
     state = state || {container: {}};
     switch (node.type) {
         case 'directive':
+            // clear previous locations in new server
+            if (node.name === 'server') {
+                state = {container: {}};
+            }
             if (node.name === 'location') {
                 state.container.previous = state.container.current;
                 state.container.current = {};

--- a/test/examples/include-server.conf
+++ b/test/examples/include-server.conf
@@ -1,0 +1,6 @@
+events {
+}
+http {
+    include includes/server-regex.conf;
+    include includes/server-equal.conf;
+}

--- a/test/examples/includes/server-equal.conf
+++ b/test/examples/includes/server-equal.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    add_header X-Header-2 ServerBlock;
+    location = /ok2 {
+        add_header X-Header-1 LocationBlock;
+        return 200;
+    }
+    location = /ok {
+        return 200;
+    }
+}

--- a/test/examples/includes/server-regex.conf
+++ b/test/examples/includes/server-regex.conf
@@ -1,0 +1,7 @@
+server {
+    listen 80;
+    add_header X-Header-2 ServerBlock;
+    location  ^~ /ordered/a/ca/a {
+        return 201;
+    }
+}


### PR DESCRIPTION
Fixes for 
```
./test/examples/include-server.conf                                                                                                                                                                                               
 within includes/server-equal.conf                                                                                                                                                                                                
  4:21 error Expected '=' location directives to be ordered before '^~' location-order
  ````
Clean previous server locations.